### PR TITLE
Missing Command Center

### DIFF
--- a/data/shipyards and outfitters.txt
+++ b/data/shipyards and outfitters.txt
@@ -279,6 +279,7 @@ outfitter basic
 	"Jump Drive"
 	"Hypderdrive"
 	"Scram Drive"
+	"Command Center"
 
 outfitter licenses
 	"Pilot's License"


### PR DESCRIPTION
Placing the Command Center in "basic" so that it can be used everywhere. While it is a Korath outfit, not just the Korath have automaton, and people may want to be able to convert automatons on other planets into pilotable ships without needing to travel.
