### PR TITLE
A tiny typo fix, removed license outfits, added Deep River transport variant

### DIFF
--- a/data/shipyards and outfitters.txt
+++ b/data/shipyards and outfitters.txt
@@ -59,7 +59,7 @@ outfitter hai
 	`"Bufaer" Atomic Steering`
 	`"Baellie" Atomic Engines`
 	"Sand Cell"
-	Railgun
+	"Railgun"
 	"Railgun Slug"
 
 outfitter human
@@ -129,9 +129,9 @@ outfitter human
 	"Anti-Missile Turret"
 	"Heavy Anti-Missile Turret"
 	"Meteor Missile"
-	Torpedo
+	"Torpedo"
 	"Sidewinder Missile"
-	Javelin
+	"Javelin"
 	"Heavy Rocket"
 	"Cargo Scanner"
 	"Small Radar Jammer"
@@ -143,12 +143,12 @@ outfitter human
 	"Heavy Rocket Launcher"
 	"Torpedo Launcher"
 	"Beam Laser"
-	Afterburner
+	"Afterburner"
 	"Outfit Scanner"
-	Supercapacitor
+	"Supercapacitor"
 	"Security Station"
 	"Laser Rifle"
-	Ramscoop
+	"Ramscoop"
 	"Laser Turret"
 	"Heavy Laser"
 	"Heavy Laser Turret"
@@ -167,7 +167,7 @@ outfitter human
 	"Typhoon Launcher"
 	"Typhoon Torpedo"
 	"Ionic Afterburner"
-	Flamethrower
+	"Flamethrower"
 	"S-270 Regenerator"
 	"S-970 Regenerator"
 	"Cloaking Device"
@@ -242,13 +242,13 @@ outfitter quarg
 	"Quantum Shield Generator"
 
 outfitter wanderer
-	Sunbeam
+	"Sunbeam"
 	"Sunbeam Turret"
 	"Dual Sunbeam Turret"
 	"Wanderer Anti-Missile"
 	"Thunderhead Missile"
 	"Thunderhead Launcher"
-	Thunderhead
+	"Thunderhead"
 	"Small Biochemical Cell"
 	"Large Biochemical Cell"
 	"Yellow Sun Reactor"
@@ -277,7 +277,7 @@ outfitter basic
 	"Cargo Expansion"
 	"Fuel Pod"
 	"Jump Drive"
-	Hyperdrive
+	"Hyperdrive"
 	"Scram Drive"
 	"Command Center"
 	"Small Bunk Room"
@@ -286,75 +286,75 @@ outfitter basic
 shipyard deprecated
 
 shipyard drak
-	Archon
+	"Archon"
 
 shipyard hai
 	"Shield Beetle"
 	"Lightning Bug"
 	"Water Bug"
-	Aphid
-	Solifuge
+	"Aphid"
+	"Solifuge"
 	"Violin Spider"
 	"Pond Strider"
-	Flea
+	"Flea"
 
 shipyard human
-	Shuttle
-	Sparrow
+	"Shuttle"
+	"Sparrow"
 	"Star Barge"
-	Hawk
-	Blackbird
-	Osprey
-	Falcon
-	Clipper
-	Fury
-	Argosy
-	Hauler
+	"Hawk"
+	"Blackbird"
+	"Osprey"
+	"Falcon"
+	"Clipper"
+	"Fury"
+	"Argosy"
+	"Hauler"
 	"Hauler II"
 	"Hauler III"
-	Bastion
-	Scout
-	Dagger
-	Flivver
-	Headhunter
-	Raven
-	Mule
-	Aerie
-	Corvette
-	Bactrian
+	"Bastion"
+	"Scout"
+	"Dagger"
+	"Flivver"
+	"Headhunter"
+	"Raven"
+	"Mule"
+	"Aerie"
+	"Corvette"
+	"Bactrian"
 	"Heavy Shuttle"
-	Berserker
-	Firebird
-	Leviathan
-	Behemoth
+	"Berserker"
+	"Firebird"
+	"Leviathan"
+	"Behemoth"
 	"Star Queen"
-	Rainmaker
-	Gunboat
-	Lance
+	"Rainmaker"
+	"Gunboat"
+	"Lance"
 	"Combat Drone"
 	"Surveillance Drone"
-	Frigate
-	Cruiser
-	Carrier
-	Quicksilver
-	Bounder
-	Splinter
-	Manta
-	Wasp
-	Freighter
+	"Frigate"
+	"Cruiser"
+	"Carrier"
+	"Quicksilver"
+	"Bounder"
+	"Splinter"
+	"Manta"
+	"Wasp"
+	"Freighter"
 	"Bulk Freighter"
-	Protector
-	Vanguard
-	Arrow
+	"Protector"
+	"Vanguard"
+	"Arrow"
 	"Modified Argosy"
-	Dreadnought
-	Skein
-	Roost
-	Nest
-	Barb
+	"Dreadnought"
+	"Skein"
+	"Roost"
+	"Nest"
+	"Barb"
 	"Barb (Proton)"
-	Boxwing
-	Finch
+	"Boxwing"
+	"Finch"
 	"Kestrel (More Shields)"
 	"Kestrel (More Weapons)"
 	"Kestrel (More Engines)"
@@ -424,12 +424,12 @@ shipyard quarg
 
 shipyard wanderer
 	"Earth Shaper"
-	Flycatcher
+	"Flycatcher"
 	"Summer Leaf"
 	"Autumn Leaf"
 	"Strong Wind"
 	"Deep River"
-	Tempest
-	Derecho
-	Hurricane
+	"Tempest"
+	"Derecho"
+	"Hurricane"
 	"Deep River Transport"

--- a/data/shipyards and outfitters.txt
+++ b/data/shipyards and outfitters.txt
@@ -59,7 +59,7 @@ outfitter hai
 	`"Bufaer" Atomic Steering`
 	`"Baellie" Atomic Engines`
 	"Sand Cell"
-	"Railgun"
+	Railgun
 	"Railgun Slug"
 
 outfitter human
@@ -277,7 +277,7 @@ outfitter basic
 	"Cargo Expansion"
 	"Fuel Pod"
 	"Jump Drive"
-	"Hyperdrive"
+	Hyperdrive
 	"Scram Drive"
 	"Command Center"
 	"Small Bunk Room"
@@ -293,10 +293,10 @@ shipyard hai
 	"Lightning Bug"
 	"Water Bug"
 	Aphid
-	"Solifuge"
+	Solifuge
 	"Violin Spider"
 	"Pond Strider"
-	"Flea"
+	Flea
 
 shipyard human
 	Shuttle
@@ -424,11 +424,12 @@ shipyard quarg
 
 shipyard wanderer
 	"Earth Shaper"
-	"Flycatcher"
+	Flycatcher
 	"Summer Leaf"
 	"Autumn Leaf"
 	"Strong Wind"
 	"Deep River"
-	"Tempest"
-	"Derecho"
-	"Hurricane"
+	Tempest
+	Derecho
+	Hurricane
+	"Deep River Transport"

--- a/data/world-forge.txt
+++ b/data/world-forge.txt
@@ -15,43 +15,8 @@ start
 conversation intro
 	scene scene/eso0
 	"Breaking the 4th wall and going straight into godmode?"
-	"	I would recommend you play the actual game. If you have done so, enjoy this. use it for testing, or just a sandbox experience."
+	"	I would recommend you play the actual game. If you have done so, enjoy this. Use it for testing, or just a sandbox experience."
 	`	For the purposes of not needing to remove this plugin every time you want to start a new pilot meant for playing the game without cheating, you have been given the normal amount of credits and starting mortgage, but you may easily go to the jobs board here on Forge and "earn" yourself some credits to pay off your mortgage and buy whatever you want.`
 	`	Special thanks to Derpy Horse, LocalGod and FallenCat and [update needed] for helping in development, and thanks for testing to:"`
 	name
 	"	Have fun!"
-
-outfit "Navy License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Cruiser License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Carrier License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Wanderer License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Wanderer Military License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Unfettered Militia License"
-	category Special
-	cost 50000
-	thumbnail outfit/license
-
-outfit "Militia Carrier License"
-	category Special
-	cost 50000
-	thumbnail outfit/license

--- a/data/world-forge.txt
+++ b/data/world-forge.txt
@@ -17,6 +17,6 @@ conversation intro
 	"Breaking the 4th wall and going straight into godmode?"
 	"	I would recommend you play the actual game. If you have done so, enjoy this. Use it for testing, or just a sandbox experience."
 	`	For the purposes of not needing to remove this plugin every time you want to start a new pilot meant for playing the game without cheating, you have been given the normal amount of credits and starting mortgage, but you may easily go to the jobs board here on Forge and "earn" yourself some credits to pay off your mortgage and buy whatever you want.`
-	`	Special thanks to Derpy Horse, LocalGod and FallenCat and [update needed] for helping in development, and thanks for testing to:"`
+	`	Special thanks to Derpy Horse, LocalGod and FallenCat and [update needed] for helping in development, and thanks for testing to:`
 	name
 	"	Have fun!"

--- a/data/world-forge.txt
+++ b/data/world-forge.txt
@@ -14,9 +14,9 @@ start
 
 conversation intro
 	scene scene/eso0
-	"Breaking the 4th wall and going straight into godmode?"
-	"	I would recommend you play the actual game. If you have done so, enjoy this. Use it for testing, or just a sandbox experience."
+	`Breaking the 4th wall and going straight into godmode?`
+	`	I would recommend you play the actual game. If you have done so, enjoy this. Use it for testing, or just a sandbox experience.`
 	`	For the purposes of not needing to remove this plugin every time you want to start a new pilot meant for playing the game without cheating, you have been given the normal amount of credits and starting mortgage, but you may easily go to the jobs board here on Forge and "earn" yourself some credits to pay off your mortgage and buy whatever you want.`
-	`	Special thanks to Derpy Horse, LocalGod and FallenCat and [update needed] for helping in development, and thanks for testing to:`
+	`	Special thanks to Derpy Horse, LocalGod and FallenCat and [update needed] for helping in development, and thanks for testing too:`
 	name
-	"	Have fun!"
+	`	Have fun!`


### PR DESCRIPTION
One commit for `shipyards and outfitters.txt`, one commit for `world-forge.txt`.
One to address https://github.com/Wrzlprnft/world-forge/issues/40, one because I have read that doing otherwise would just let you purchase a license if you want a ship that needed it, even if that license is restricted to missions or not available on the planet.

Note that this is my first pull request, so be gentle~
