### PR TITLE
Arena korath bounties

### DIFF
--- a/data/arena.txt
+++ b/data/arena.txt
@@ -17,10 +17,10 @@ mission "Remnant: Bounty (Raider - Crippled)"
 	name "Remnant bounty (Raider - Crippled)"
 	description "Hunt down a crippled Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality coward target waiting
+		personality coward target uninterested marked waiting
 		system
 			system "Arena"
 		fleet
@@ -46,7 +46,7 @@ mission "Remnant: Bounty 2 (Raider - Hyperdrive)"
 		government "Remnant"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -69,10 +69,10 @@ mission "Remnant: Bounty NA (World Ship - Crippled)"
 	name "Remnant bounty (World Ship - Crippled)"
 	description "Hunt down a crippled Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality coward target waiting
+		personality coward target uninterested marked waiting
 		system
 			system "Arena"
 		fleet
@@ -95,10 +95,10 @@ mission "Remnant: Bounty NA (Korath World-Ship B (Ember))"
 	name "Remnant bounty (Korath World-Ship B (Ember))"
 	description "Hunt down a Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -121,10 +121,10 @@ mission "Remnant: Bounty NA (1 Korath Chasers)"
 	name "Remnant bounty (1 Korath Chasers)"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -147,10 +147,10 @@ mission "Remnant: Bounty NA (2 Korath Chasers)"
 	name "Remnant bounty (2 Korath Chasers)"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -173,10 +173,10 @@ mission "Remnant: Bounty NA (2 Korath Chasers)b"
 	name "Remnant bounty (2 Korath Chasers)b"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -199,10 +199,10 @@ mission "Remnant: Bounty NA (5 Korath Chasers)"
 	name "Remnant bounty (5 Korath Chasers)"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -225,10 +225,10 @@ mission "Remnant: Bounty NA (C Raider + Chasers)"
 	name "Remnant bounty (C Raider + Chasers)"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet
@@ -252,10 +252,10 @@ mission "Remnant: Bounty NA (H Raider + Chasers)"
 	name "Remnant bounty (H Raider + Chasers)"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
-		attribute "CombatBoard"
+		attributes "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic target waiting
+		personality heroic vindictive target uninterested waiting marked
 		system
 			system "Arena"
 		fleet

--- a/data/arena.txt
+++ b/data/arena.txt
@@ -20,7 +20,7 @@ mission "Remnant: Bounty (Raider - Crippled)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality coward target uninterested marked waiting
+		personality coward target waiting
 		system
 			system "Arena"
 		fleet
@@ -46,7 +46,7 @@ mission "Remnant: Bounty 2 (Raider - Hyperdrive)"
 		government "Remnant"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -72,7 +72,7 @@ mission "Remnant: Bounty NA (World Ship - Crippled)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality coward target uninterested marked waiting
+		personality coward target waiting
 		system
 			system "Arena"
 		fleet
@@ -98,7 +98,7 @@ mission "Remnant: Bounty NA (Korath World-Ship B (Ember))"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -124,7 +124,7 @@ mission "Remnant: Bounty NA (1 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -150,7 +150,7 @@ mission "Remnant: Bounty NA (2 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -176,7 +176,7 @@ mission "Remnant: Bounty NA (2 Korath Chasers)b"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -202,7 +202,7 @@ mission "Remnant: Bounty NA (5 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -228,7 +228,7 @@ mission "Remnant: Bounty NA (C Raider + Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet
@@ -255,7 +255,7 @@ mission "Remnant: Bounty NA (H Raider + Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target uninterested waiting marked
+		personality heroic vindictive target waiting
 		system
 			system "Arena"
 		fleet

--- a/data/arena.txt
+++ b/data/arena.txt
@@ -22,7 +22,7 @@ mission "Remnant: Bounty (Raider - Crippled)"
 		government "Korath"
 		personality coward target uninterested marked waiting
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -48,7 +48,7 @@ mission "Remnant: Bounty 2 (Raider - Hyperdrive)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -74,7 +74,7 @@ mission "Remnant: Bounty NA (World Ship - Crippled)"
 		government "Korath"
 		personality coward target uninterested marked waiting
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -100,13 +100,39 @@ mission "Remnant: Bounty NA (Korath World-Ship B (Ember))"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
 			variant
 				"Korath World-Ship B (Ember)"
 		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (1 Korath Chasers)"
+	job
+	repeat
+	name "Remnant bounty (1 Korath Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			system "Arena"
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Chaser"
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
 	on visit
 		dialog phrase "generic bounty hunting on visit"
 	on complete
@@ -126,7 +152,7 @@ mission "Remnant: Bounty NA (2 Korath Chasers)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -141,10 +167,10 @@ mission "Remnant: Bounty NA (2 Korath Chasers)"
 
 
 
-mission "Remnant: Bounty NA (3 Korath Chasers)"
+mission "Remnant: Bounty NA (2 Korath Chasers)b"
 	job
 	repeat
-	name "Remnant bounty (3 Korath Chasers)"
+	name "Remnant bounty (2 Korath Chasers)b"
 	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
 	source
 		attribute "CombatBoard"
@@ -152,12 +178,12 @@ mission "Remnant: Bounty NA (3 Korath Chasers)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
 			variant
-				"Korath Chaser" 3
+				"Korath Chaser" 2
 		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
 	on visit
 		dialog phrase "generic bounty hunting on visit"
@@ -178,7 +204,7 @@ mission "Remnant: Bounty NA (5 Korath Chasers)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -204,7 +230,7 @@ mission "Remnant: Bounty NA (C Raider + Chasers)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3
@@ -231,7 +257,7 @@ mission "Remnant: Bounty NA (H Raider + Chasers)"
 		government "Korath"
 		personality heroic vindictive target uninterested waiting marked
 		system
-			Arena
+			system "Arena"
 		fleet
 			names "korath"
 			cargo 3

--- a/data/arena.txt
+++ b/data/arena.txt
@@ -46,7 +46,7 @@ mission "Remnant: Bounty 2 (Raider - Hyperdrive)"
 		government "Remnant"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -98,7 +98,7 @@ mission "Remnant: Bounty NA (Korath World-Ship B (Ember))"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -124,7 +124,7 @@ mission "Remnant: Bounty NA (1 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -150,7 +150,7 @@ mission "Remnant: Bounty NA (2 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -176,7 +176,7 @@ mission "Remnant: Bounty NA (2 Korath Chasers)b"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -202,7 +202,7 @@ mission "Remnant: Bounty NA (5 Korath Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -228,7 +228,7 @@ mission "Remnant: Bounty NA (C Raider + Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet
@@ -255,7 +255,7 @@ mission "Remnant: Bounty NA (H Raider + Chasers)"
 		attribute "CombatBoard"
 	npc kill
 		government "Korath"
-		personality heroic vindictive target waiting
+		personality heroic target waiting
 		system
 			system "Arena"
 		fleet

--- a/data/arena.txt
+++ b/data/arena.txt
@@ -1,0 +1,246 @@
+# Copyright (c) 2017 by Michael Zahniser
+# Copyright (c) 2018 by Zitchas
+#
+# Endless Sky is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+
+
+mission "Remnant: Bounty (Raider - Crippled)"
+	job
+	repeat
+	name "Remnant bounty (Raider - Crippled)"
+	description "Hunt down a crippled Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality coward target uninterested marked waiting
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Raider (Crippled)"
+		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 300000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty 2 (Raider - Hyperdrive)"
+	job
+	repeat
+	name "Remnant bounty 2 (Raider - Hyperdrive)"
+	description "Hunt down a Korath ship that is lurking in Remnant territory, then return to <planet> to receive your payment of <payment>."
+	source
+		government "Remnant"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Raider (Hyperdrive)"
+		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 400000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (World Ship - Crippled)"
+	job
+	repeat
+	name "Remnant bounty (World Ship - Crippled)"
+	description "Hunt down a crippled Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality coward target uninterested marked waiting
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath World-Ship B (Crippled)"
+		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 500000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (Korath World-Ship B (Ember))"
+	job
+	repeat
+	name "Remnant bounty (Korath World-Ship B (Ember))"
+	description "Hunt down a Korath ship that is lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath World-Ship B (Ember)"
+		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (2 Korath Chasers)"
+	job
+	repeat
+	name "Remnant bounty (2 Korath Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Chaser" 2
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (3 Korath Chasers)"
+	job
+	repeat
+	name "Remnant bounty (3 Korath Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Chaser" 3
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (5 Korath Chasers)"
+	job
+	repeat
+	name "Remnant bounty (5 Korath Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Chaser" 5
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (C Raider + Chasers)"
+	job
+	repeat
+	name "Remnant bounty (C Raider + Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Raider (Crippled)"
+				"Korath Chaser" 2
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."
+
+
+
+mission "Remnant: Bounty NA (H Raider + Chasers)"
+	job
+	repeat
+	name "Remnant bounty (H Raider + Chasers)"
+	description "Hunt down the Korath ships that are lurking in Arena, then return to <planet> to receive your payment of <payment>."
+	source
+		attribute "CombatBoard"
+	npc kill
+		government "Korath"
+		personality heroic vindictive target uninterested waiting marked
+		system
+			Arena
+		fleet
+			names "korath"
+			cargo 3
+			variant
+				"Korath Raider (Hyperdrive)"
+				"Korath Chaser" 2
+		dialog "You have destroyed the Korath ships. You can now return to <planet> to collect your payment."
+	on visit
+		dialog phrase "generic bounty hunting on visit"
+	on complete
+		payment 600000
+		dialog "The Remnant military leader station here thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>. He notes that they currently don't have a communication link to the Remnant worlds, so everyone back home won't know this mission happened."

--- a/data/map.txt
+++ b/data/map.txt
@@ -754,7 +754,7 @@ planet Drak
 	security 0
 
 planet Forge
-	attributes forge forgedrak forgehai forgehuman forgekorath forgepug forgewanderer forgequarg forgecoalition
+	attributes forge forgedrak forgehai forgehuman forgekorath forgepug forgewanderer forgequarg forgecoalition combatboard
 	landscape hochofen
 	description `Race: all`
 	description `	Ships: all`


### PR DESCRIPTION
This PR adds the "CombatBoard" attribute to Planet Forge, and a bunch of missions that spawn Korath in the Arena system. These missions have no pre-requisistes, and will spawn on any planet with the "CombatBoard" attribute. So if you setup a specific combat/arena planet later on, these will move over seemlessly.

All the missions are virtually identical, as in they ask the player to kill one or more Korath ships, spawned in the Arena system. That being said, none of these have the "staying" personality, so the player will still have to track them down. All of them are "targeted," but none of them are "marked." So these missions can be used to setup AI fleet battles as well. The two lone crippled ships have "coward," all the rest are "heroic." The mission choices are:
- 1 crippled raider
- 1 hyperdrive raider
- 1 crippled world ship
- 1 world ship B (ember)
- 1 chaser
- 2 chaser (two of these)
- 5 chaser
- 1 crippled raider with 2 chasers
- 1 hyperdrive raider with 2 chasers

As a result of these combinations, one can basically "build" a fleet with any combination of :
- 0 to 14 chasers
- 0 to 2 crippled raiders
- 0 to 2 hyperdrive raiders
- 0 to 1 crippled world ship
- 0 to 1 world ship B (ember)
 (with the caveat that if one is getting the second of either raider, one will have a minimum of 2 chasers)

Given that World-Forge is built for content creators, it might be useful for people to have a customizable set of fleets to test ships and outfits against.