### PR TITLE
The game now accepts the existence of the wormhole in Origin.

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -1015,3 +1015,6 @@ planet Wanderer
 	outfitter drive
 	outfitter basic
 	security 0
+
+planet Rupture
+


### PR DESCRIPTION
Without this PR, the game would output
```
Warning: planet "Rupture" is referred to, but never defined.
```
I just followed the format of the Pug wormhole. I *think* this should work fine.