### PR TITLE
Planet with all Marauder ships and their base versions

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -297,7 +297,7 @@ system Human
 			sprite planet/luna
 			distance 201.24
 			period 27.3
-	object
+	object Marauder
 		sprite planet/mars
 		distance 1471.43
 		period 687
@@ -948,6 +948,23 @@ planet MarauderW
 	outfitter basic
 	security 0
 	
+planet Marauder
+	attributes forge forgehuman
+	landscape land/human
+	description `Race: Human`
+	description `	Ships: Marauders and base versions`
+	description `	Outfits: Human`
+	description `	Note: No other variants`
+	spaceport ""
+	shipyard unmarauder
+	shipyard marauder
+	shipyard maraudere
+	shipyard marauderw
+	outfitter human
+	outfitter drive
+	outfitter basic
+	security 0
+
 planet Mods
 	attributes forge
 	landscape ""

--- a/data/shipyards and outfitters.txt
+++ b/data/shipyards and outfitters.txt
@@ -622,6 +622,18 @@ shipyard marauderw
 	"Marauder Raven (Weapons)"
 	"Marauder Splinter (Weapons)"
 
+shipyard unmarauder
+	"Arrow"
+	"Bounder"
+	"Falcon"
+	"Firebird"
+	"Fury"
+	"Leviathan"
+	"Manta"
+	"Quicksilver"
+	"Raven"
+	"Splinter"
+
 shipyard pug
 	"Pug Zibruka"
 	"Pug Enfolta"

--- a/data/shipyards and outfitters.txt
+++ b/data/shipyards and outfitters.txt
@@ -590,6 +590,7 @@ shipyard korath
 
 shipyard marauder
 	"Marauder Arrow"
+	"Marauder Bactrian"
 	"Marauder Bounder"
 	"Marauder Falcon"
 	"Marauder Firebird"
@@ -624,6 +625,7 @@ shipyard marauderw
 
 shipyard unmarauder
 	"Arrow"
+	"Bactrian"
 	"Bounder"
 	"Falcon"
 	"Firebird"


### PR DESCRIPTION
#61 
~Not including the Marauder Bactrian since that's a person ship.~
@Zitchas does this meet your request?