### PR TITLE
Fix some possible typos

### DIFF
--- a/data/Developer Drive.txt
+++ b/data/Developer Drive.txt
@@ -23,4 +23,4 @@ outfit "Developer Drive"
 	"fuel capacity" 100
 	"tactical scan power" 9999
 	description "Both a hyperdrive and a jump drive able to jump at any speed and a key to the most mysterious places in the galaxy, this fantastic device lets you travel wherever you want, whenever you want, and all for 1 fuel each warp! Built in cloaking means that you don't need to fight when you don't want to, and the 600 fuel generation means that you'll be regenerating that 1 fuel used per jump pretty quickly."
-	description "Perfect for any developer looking to quickly test things out or just someone who wants to visit all the systems in the game as fast as possible."
+	description "	Perfect for any developer looking to quickly test things out or just someone who wants to visit all the systems in the game as fast as possible."

--- a/data/Paint.txt
+++ b/data/Paint.txt
@@ -94,7 +94,7 @@ mission "Swizzle 0"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 0 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 0 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -111,7 +111,7 @@ mission "Swizzle 1"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 1 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 1 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -128,7 +128,7 @@ mission "Swizzle 2"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 2 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 2 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -145,7 +145,7 @@ mission "Swizzle 3"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 3 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 3 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -162,7 +162,7 @@ mission "Swizzle 4"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 4 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 4 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -179,7 +179,7 @@ mission "Swizzle 5"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 5 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 5 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept
@@ -196,7 +196,7 @@ mission "Swizzle 6"
 	source Painter
 	on offer
 		conversation
-			`	Swizzle 6 detected. Are you sure you want to apply the new Colour to your Fleet?`
+			`	Swizzle 6 detected. Are you sure you want to apply the new Color to your Fleet?`
 			choice
 				`	Yes, paint it.`
 					accept

--- a/data/jobs.txt
+++ b/data/jobs.txt
@@ -185,7 +185,7 @@ mission "Remove Licenses"
 	job
 	source
 		attributes forge
-	description "Removes all licenses. You can readd the licenses you want by departing the planet and returning to the job board."
+	description "Removes all licenses. You can re-add the licenses you want by departing the planet and returning to the job board."
 	on accept
 		clear "license: Pilot's"
 		clear "license: City-Ship"


### PR DESCRIPTION
1. Add in a missing indent to the description of the Developer Drive.
2. Turn "Colour" into "Color" because I think Endless Sky stuff uses American English. Not sure about it here, though.
3. Add in a missing dash and turn "readd" into "re-add"