### PR TITLE
Typo/0.10.5 fixes

### DIFF
--- a/data/map reveal.txt
+++ b/data/map reveal.txt
@@ -1,8 +1,8 @@
 outfit "Galaxy Map"
-	thumbnail "outfit/map"
-	map 1000
-	cost 0
 	category "Special"
+	cost 0
+	map 10000
+	thumbnail "outfit/map"
 
 
 
@@ -12,19 +12,19 @@ planet "New Boston"
 
 
 mission "Map Reveal"
-	description `Reveal the entire map in one go! Accept this job and launch and all vanilla systems and planets will be visited.`
 	job
 	repeat
+	description "Reveal the entire map in one go! Accept this job and all vanilla systems and planets will be visited."
 	source
 		attributes forge "map reveal"
 	on offer
-		event "VISIT_EVERYTHING"
+		event "VISIT_EVERYTHING" 0
 		fail
 
 
 
-# Commented out line indicate defined planets that are not assigned to any objects at the start of the game.
-# They cannot be visited and attemmpting to do so renders this event invalid.
+# Commented out lines indicate defined planets that are not assigned to any objects at the start of the game.
+# They cannot be visited and attempting to say they are renders this event invalid.
 event "VISIT_EVERYTHING"
 	visit "1 Axis"
 	visit "10 Pole"
@@ -102,6 +102,7 @@ event "VISIT_EVERYTHING"
 	visit "Alphard"
 	visit "Alphecca"
 	visit "Alpheratz"
+	visit "Alpherg"
 	visit "Altair"
 	visit "Aludra"
 	visit "Anbrim"
@@ -126,6 +127,7 @@ event "VISIT_EVERYTHING"
 	visit "Avo Chigo"
 	visit "Aya'k'k"
 	visit "Beginning"
+	visit "Belenos"
 	visit "Bellatrix"
 	visit "Belonging"
 	visit "Belug"
@@ -159,6 +161,7 @@ event "VISIT_EVERYTHING"
 	visit "Chornifath"
 	visit "Chy'chra"
 	visit "Cinxia"
+	visit "Citadelle"
 	visit "Coalition"
 	visit "Coluber"
 	visit "Companion"
@@ -252,6 +255,7 @@ event "VISIT_EVERYTHING"
 	visit "Fornarep"
 	visit "Four Pillars"
 	visit "Fscher"
+	visit "Fumalsamakah"
 	visit "Furmeliki"
 	visit "G-3191"
 	visit "G-6183"
@@ -541,6 +545,7 @@ event "VISIT_EVERYTHING"
 	visit "Terminus"
 	visit "Terra Incognita"
 	visit "Thshybo Le"
+	visit "Thuban"
 	visit "Torbab"
 	visit "Tortor"
 	visit "Tscera"
@@ -608,6 +613,7 @@ event "VISIT_EVERYTHING"
 	"visit planet" "Alix"
 	"visit planet" "Allhome"
 	"visit planet" "Alta Hai"
+	"visit planet" "Alvorada"
 	"visit planet" "Amazon"
 	"visit planet" "Angko"
 	"visit planet" "Antipode"
@@ -758,6 +764,7 @@ event "VISIT_EVERYTHING"
 	"visit planet" "Freedom"
 	"visit planet" "Frostmark"
 	"visit planet" "Furnace"
+	"visit planet" "Gagarin"
 	"visit planet" "Gara Pvu"
 	"visit planet" "Garden Empyreal"
 	"visit planet" "Gegno"
@@ -814,6 +821,7 @@ event "VISIT_EVERYTHING"
 	"visit planet" "Into White"
 	"visit planet" "Iritoroost"
 	"visit planet" "Ironfirth"
+	"visit planet" "Jakobsen"
 	"visit planet" "Janiculum"
 	"visit planet" "Jentuthro"
 	"visit planet" "Jupiter"
@@ -857,6 +865,7 @@ event "VISIT_EVERYTHING"
 	"visit planet" "Mebla's Portion"
 	"visit planet" "Melenci"
 	"visit planet" "Memory"
+	"visit planet" "Mendez Station"
 	"visit planet" "Merask Fortuno"
 	"visit planet" "Mere"
 	"visit planet" "Mereti Station"
@@ -869,6 +878,7 @@ event "VISIT_EVERYTHING"
 	"visit planet" "Mods"
 	#"visit planet" "Mooncreek"
 	"visit planet" "Moonshake"
+	"visit planet" "Mordente-Bridi"
 	#"visit planet" "Mountaintop"
 	"visit planet" "Muninn Station"
 	"visit planet" "Muspel"

--- a/data/map reveal.txt
+++ b/data/map reveal.txt
@@ -1,8 +1,8 @@
 outfit "Galaxy Map"
 	category "Special"
 	cost 0
-	map 10000
 	thumbnail "outfit/map"
+	map 10000
 
 
 
@@ -14,9 +14,9 @@ planet "New Boston"
 mission "Map Reveal"
 	job
 	repeat
-	description "Reveal the entire map in one go! Accept this job and all vanilla systems and planets will be visited."
 	source
 		attributes forge "map reveal"
+	description "Reveal the entire map in one go! Accept this job and all vanilla systems and planets will be visited."
 	on offer
 		event "VISIT_EVERYTHING" 0
 		fail

--- a/data/map reveal.txt
+++ b/data/map reveal.txt
@@ -14,9 +14,9 @@ planet "New Boston"
 mission "Map Reveal"
 	job
 	repeat
+	description "Reveal the entire map in one go! Accept this job and all vanilla systems and planets will be visited."
 	source
 		attributes forge "map reveal"
-	description "Reveal the entire map in one go! Accept this job and all vanilla systems and planets will be visited."
 	on offer
 		event "VISIT_EVERYTHING" 0
 		fail

--- a/data/map reveal.txt
+++ b/data/map reveal.txt
@@ -24,7 +24,7 @@ mission "Map Reveal"
 
 
 # Commented out lines indicate defined planets that are not assigned to any objects at the start of the game.
-# They cannot be visited and attempting to say they are renders this event invalid.
+# They cannot be visited and attempting to do so renders this event invalid.
 event "VISIT_EVERYTHING"
 	visit "1 Axis"
 	visit "10 Pole"


### PR DESCRIPTION
Fixes a typo or two in map.txt, fixes some things that were in the wrong order, and adds the systems/planets from 0.10.5 to the map reveal.